### PR TITLE
Add regex support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist/
 /wireguard-vanity-keygen
+/wireguard-vanity-keygen.exe
 /cmd/wg-vanity-keygen/wg-vanity-keygen

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A command-line vanity (public) key generator for [WireGuard](https://www.wiregua
 - Generates compliant [curve25519](https://cr.yp.to/ecdh.html) private and public keys
 - Configurable multi-core processing (defaults to all cores)
 - Optional case sensitive searching
+- Optional regex searching
 - Search multiple prefixes at once
 - Exit after results limit reached (defaults to 1)
 - Displays probability and estimated runtime based on quick benchmark
@@ -30,11 +31,12 @@ Options:
 ## Example
 
 ```
-$ wireguard-vanity-keygen -l 4 test pc1/ 
+$ wireguard-vanity-keygen -l 3 test pc1/ "^(abc|def)"
 Calculating speed: 49,950 calculations per second using 4 CPU cores
 Case-insensitive search, exiting after 4 results
 Probability for "test": 1 in 2,085,136 (approx 41 seconds per match)
 Probability for "pc1/": 1 in 5,914,624 (approx 1 minute per match)
+Probability for "^(abc|def)": 1 in 3,010,936,384 (approx 3 hours, 40 minutes per match) (approximation may be wildly off, as 'abcdef' is test string)
 
 Press Ctrl-c to cancel
 
@@ -42,10 +44,11 @@ private OFVUjUoTNQp94fNPB9GCLzxiJPTbN03rcDPrVd12uFc=   public tEstMXL/3ZzAd2TnVl
 private gInIEDmENYbyuaWR1W/KLfximExwbcCg45W2WOmEc0I=   public TestKmA/XVagDW/JsHBXk5mhYJ6E1N1lAWeIeCttgRs=
 private yDQLNiQlfnMGhUBsbLQjoBbuNezyHug31Qa1Ht6cgkw=   public PC1/3oUId241TLYImJLUObR8NNxz4HXzG4z+EazfWxY=
 private +CUqn4jcKoL8pw53pD4IzfMKW/IMceDWKcM2W5Dxtn4=   public teStmGXZwiJl9HmfnTSmk83girtiIH8oZEa6PFJ8F1Y=
-private 2G0X+IvBLw3NRfRnHb8diIXp96NQ9wSu4gdqPidy3nw=   public tESt3DBU40Q/Zkp0d1aeb6HOgEOsEM3BxzNqLckKhhc=
 private EMaUfQvAEABpQV/21ALJP5YtyGerRXAn8u67j2AQzVs=   public pC1/t2x5V99Y1SBqNgPZDPsa6r+L5y3BJ4XUCJMar3g=
 private wNuHOKCfoH1emfvijXNBoc/7KjrEXUeof7tSdGWvRFo=   public PC1/jXQosaBad2HePOm/w1KjCZ82eT3qNbfzNDZiwTs=
-private 8IdcNsman/ZRGvqWzw1e5cRfhhdtAAmk02X9TkQxhHI=   public pC1/N8coOcXmcwO09QXxLrF5/BoHQfvp/qsysGPXiw0=
+private ACcI8j3TfWtGtZIqaf8a6qAxUx5fcuROMls2HRR3yGs=   public AbcP+qWv8OtXGHW2s2xWi8/uMNU7PxyDJZWcb0kQ5Ds=
+private KLBbXjsdWoF+FKVzTsJh//90rNxrUeBAxw5b4CaXDXI=   public DEfYIHnja/EP4KYcvwdbQcu03ITMXIHLoeC3d0ppkAw=
+private 0DB5zytfbxDs/fo0wmZBO12KbfeSTmxUD8S9ZQUXpWg=   public defP6d76lpIGu6aoBjKza16dZKirr5yzr5SKqihx2xw=
 ```
 
 
@@ -70,6 +73,8 @@ but increasing the limit to two (`--limit 2`) will double the estimated time, th
 
 If any search term contains numbers, the timings would fall somewhere between the case-insensitive and case-sensitive columns.
 
+Most regex expressions that include the pipe character (`|`), such as `^(abc|def)`, will cause the calculation to be wildly off.
+
 Of course, your mileage will differ, depending on the number, and speed, of your CPU cores.
 
 ## Installing
@@ -84,6 +89,7 @@ or build from source `go install github.com/axllent/wireguard-vanity-keygen@late
 
 Valid characters include `A-Z`, `a-z`, `0-9`, `/` and `+`. There are no other characters in a hash.
 
+You can also use regex expressions to search.
 
 ### Why does `test` & `tes1` show different probabilities despite having 4 characters each?
 

--- a/README.md
+++ b/README.md
@@ -31,26 +31,25 @@ Options:
 ## Example
 
 ```
-$ wireguard-vanity-keygen -l 3 test pc1/ "^(abc|def)"
+$ wireguard-vanity-keygen -l 3 test pc1/ "^pc7[+/]"
 Calculating speed: 49,950 calculations per second using 4 CPU cores
 Case-insensitive search, exiting after 4 results
 Probability for "test": 1 in 2,085,136 (approx 41 seconds per match)
 Probability for "pc1/": 1 in 5,914,624 (approx 1 minute per match)
-Probability for "^(abc|def)": 1 in 3,010,936,384 (approx 3 hours, 40 minutes per match) (approximation may be wildly off, as 'abcdef' is test string)
+Cannot calculate probability for the regular expression "^pc7[/+]"
 
 Press Ctrl-c to cancel
 
 private OFVUjUoTNQp94fNPB9GCLzxiJPTbN03rcDPrVd12uFc=   public tEstMXL/3ZzAd2TnVlr1BNs/+eOnKzSHpGUnjspk3kc=
 private gInIEDmENYbyuaWR1W/KLfximExwbcCg45W2WOmEc0I=   public TestKmA/XVagDW/JsHBXk5mhYJ6E1N1lAWeIeCttgRs=
 private yDQLNiQlfnMGhUBsbLQjoBbuNezyHug31Qa1Ht6cgkw=   public PC1/3oUId241TLYImJLUObR8NNxz4HXzG4z+EazfWxY=
+private QIbJgxy83+F/1kdogcF+T04trs+1N9gAr1t5th2tLXM=   public Pc7+h172sx0TfIMikjgszM/B8i8/ghi7qJVOwWQtx0w=
 private +CUqn4jcKoL8pw53pD4IzfMKW/IMceDWKcM2W5Dxtn4=   public teStmGXZwiJl9HmfnTSmk83girtiIH8oZEa6PFJ8F1Y=
 private EMaUfQvAEABpQV/21ALJP5YtyGerRXAn8u67j2AQzVs=   public pC1/t2x5V99Y1SBqNgPZDPsa6r+L5y3BJ4XUCJMar3g=
 private wNuHOKCfoH1emfvijXNBoc/7KjrEXUeof7tSdGWvRFo=   public PC1/jXQosaBad2HePOm/w1KjCZ82eT3qNbfzNDZiwTs=
-private ACcI8j3TfWtGtZIqaf8a6qAxUx5fcuROMls2HRR3yGs=   public AbcP+qWv8OtXGHW2s2xWi8/uMNU7PxyDJZWcb0kQ5Ds=
-private KLBbXjsdWoF+FKVzTsJh//90rNxrUeBAxw5b4CaXDXI=   public DEfYIHnja/EP4KYcvwdbQcu03ITMXIHLoeC3d0ppkAw=
-private 0DB5zytfbxDs/fo0wmZBO12KbfeSTmxUD8S9ZQUXpWg=   public defP6d76lpIGu6aoBjKza16dZKirr5yzr5SKqihx2xw=
+private gJtn0woDChGvyN2eSdc7mTpAFA/nA6jykJeK5bYYfFA=   public Pc7+UEJSHiWsQ9zkO2q+guqDK4sc3VMDMgJu+h/bOFI=
+private IMyPmYm/v0SPmB62hC8l6kfxT3/Lfp7dMioo+SM6T2c=   public Pc7/uVfD/ZftxWBHwYbaudEywUS61biBcpj5Tw830Q4=
 ```
-
 
 ## Timings
 
@@ -67,15 +66,33 @@ estimated timings for each match on a system that reported  "`Calculating speed:
 | 8 chars | 7 months         | 38 years       |
 | 9 chars | 22 years         | 175 years      |
 
-Note that the above timings are for finding a result for any search term. 
-Passing multiple search terms will not substantially increase the time, 
+Note that the above timings are for finding a result for any search term.
+Passing multiple search terms will not substantially increase the time,
 but increasing the limit to two (`--limit 2`) will double the estimated time, three will triple the time, etc.
 
 If any search term contains numbers, the timings would fall somewhere between the case-insensitive and case-sensitive columns.
 
-Most regex expressions that include the pipe character (`|`), such as `^(abc|def)`, will cause the calculation to be wildly off.
-
 Of course, your mileage will differ, depending on the number, and speed, of your CPU cores.
+
+## Regular Expressions
+
+Since each additional letter in a search term increasing the search time exponentially, searching by regular expression may
+reduce the time considerably. Here are some examples:
+
+1. `.*word.*` - find word anywhere in the key (`word.*` and `.*word` will also work)
+2. `^.{0,10}word` - find word anywhere in the first 10 letters of the key
+3. `word1.*word2` - find two words, anywhere in the key
+4. `^[s5][o0][ll]ar` - find 'solar' or the visually similar 's01ar`, at the beginning of the key
+5. `^(best|next)[/+]` - find 'best' or the 'next' best, at the beginning of the key, with `/` or `+` as a delimiter
+
+A good guide on Go's regular expression syntax is at https://pkg.go.dev/regexp/syntax.
+
+NOTE: If your search term contains shell metacharacters, such as `|`, or `^`, you will need to quote the search time.
+On Windows, you must use double quotes (`"`), and not single quotes (`'`) when quoting a search term.
+
+NOTE: It is possible to create regular expressions that will never match a key.
+To guard against this, shorten your search term to use just one character in each section of your regular expression.
+If you don't get a hit after a few minutes, assume the regular expression may never match.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -76,23 +76,24 @@ Of course, your mileage will differ, depending on the number, and speed, of your
 
 ## Regular Expressions
 
-Since each additional letter in a search term increasing the search time exponentially, searching by regular expression may
+Since each additional letter in a search term increases the search time exponentially, searching using a regular expression may
 reduce the time considerably. Here are some examples:
 
 1. `.*word.*` - find word anywhere in the key (`word.*` and `.*word` will also work)
 2. `^.{0,10}word` - find word anywhere in the first 10 letters of the key
 3. `word1.*word2` - find two words, anywhere in the key
-4. `^[s5][o0][ll]ar` - find 'solar' or the visually similar 's01ar`, at the beginning of the key
-5. `^(best|next)[/+]` - find 'best' or the 'next' best, at the beginning of the key, with `/` or `+` as a delimiter
+4. `^[s5][o0][ll]ar` - find 'solar', or the visually similar 's01ar`, at the beginning of the key
+5. `^(best|next)[/+]` - find 'best', or the 'next' best, at the beginning of the key, with `/` or `+` as a delimiter
 
 A good guide on Go's regular expression syntax is at https://pkg.go.dev/regexp/syntax.
 
-NOTE: If your search term contains shell metacharacters, such as `|`, or `^`, you will need to quote the search time.
-On Windows, you must use double quotes (`"`), and not single quotes (`'`) when quoting a search term.
+To include a `+` in your regular expression, preface it with a backslash, like `\+`.
 
-NOTE: It is possible to create regular expressions that will never match a key.
-To guard against this, shorten your search term to use just one character in each section of your regular expression.
-If you don't get a hit after a few minutes, assume the regular expression may never match.
+NOTE: If your search term contains shell metacharacters, such as `|`, or `^`, you will need to quote it.
+On Windows, you must use double quotes. For example: `"^(a|b)"`.
+
+NOTE: Complex regular expressions, such as those using escape sequences, flags, or character classes, may never match a key.
+To avoid that, consider testing your regex using a tool such as [this one](https://go.dev/play/p/6LJy51Wd08O).
 
 ## Installing
 

--- a/keygen/utils.go
+++ b/keygen/utils.go
@@ -13,10 +13,18 @@ import (
 // which is valid in a key
 const regexChars = `^$.|?*-[]{}()\`
 
+// regexWillNeverMatch is a shared error message that the regex will never match
+const regexWillNeverMatch = "The regular expression will never match"
+
 // IsValidSearch checks the search does not contain any invalid characters
 func IsValidSearch(s string) bool {
 	var r = regexp.MustCompile(`[^a-zA-Z0-9\/\+]`)
 	return !r.MatchString(s)
+}
+
+// InvalidSearchMsg returns the error message the search term contains invalid characters
+func InvalidSearchMsg(s string) string {
+	return fmt.Sprintf("\n\"%s\" contains invalid characters\nValid characters include letters [a-z], numbers [0-9], + and /", s)
 }
 
 // HumanizeDuration returns a human-readable output of time.Duration
@@ -93,19 +101,107 @@ func NumberFormat(n int64) string {
 	}
 }
 
-func RemoveMetacharacters(s string) string {
-	if !strings.ContainsAny(s, regexChars) {
-		return s
+// IsRegex returns true if any regex metacharacters (except +) are in the search term
+func IsRegex(s string) bool {
+	return strings.ContainsAny(s, regexChars)
+}
+
+// invalidRegexMsg returns an error message how the regex is invalid
+func invalidRegexMsg(s string, errmsg string) string {
+	return fmt.Sprintf("\n\"%s\" is an invalid regular expression\n%s", s, errmsg)
+}
+
+// IsValidRegex checks the regex has any chance of matching a key
+func IsValidRegex(s string) string {
+	// A consise guide on golang's regex syntax is at
+	// https://pkg.go.dev/regexp/syntax
+
+	stripped := removeMetacharacters(s)
+	if !IsValidSearch(stripped) {
+		return InvalidSearchMsg(s)
 	}
-	// remove (?i)
-	re1 := regexp.MustCompile(`^\([^)]*\)`)
-	s = re1.ReplaceAllLiteralString(s, "")
-	// replace [a-b]+ with a
-	re2 := regexp.MustCompile(`\[[^]]*\]\+?`)
-	s = re2.ReplaceAllLiteralString(s, "a")
-	// strip all {n}
-	re3 := regexp.MustCompile(`\{[^}]+\}`)
-	s = re3.ReplaceAllLiteralString(s, "")
+
+	// Expressions with '^' character
+	re := regexp.MustCompile(`.\^`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, "The '^' character must appear at the beginning of the search term")
+	}
+
+	// Expressions with '$' character
+	re = regexp.MustCompile(`\$.`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, "The '$' character must appear at the end of the search term")
+	}
+	re = regexp.MustCompile(`[^=]\$`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, "A search at the end of the string must contain an '=' character, as all keys end with an `=`")
+	}
+	re = regexp.MustCompile(`=[^$]`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, "The '=' character can only appear at the end of a key")
+	}
+	// The command:
+	// wireguard-vanity-keygen -l 1000 . | grep private | cut -c 105- | sort -u | tr -d "=" | tr -d "\n"
+	// outputs:
+	// 048AEIMQUYcgkosw
+	re = regexp.MustCompile(`[^048AEIMQUYcgkosw]=\$`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, regexWillNeverMatch)
+	}
+
+	// Expressions with backslashes:
+
+	// A regex of just a backslash and a single character will never match
+	re = regexp.MustCompile(`^\\.$`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, regexWillNeverMatch)
+	}
+
+	// Control characters and many octal values will meter match, disallow them all
+	re = regexp.MustCompile(`\\[aftnrxswWpP0-7]`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, regexWillNeverMatch)
+	}
+
+	// Disallow backslashes followed by any non-alnum or + character
+	re = regexp.MustCompile(`\\[^A-Za-z0-9+]`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, regexWillNeverMatch)
+	}
+
+	// Expressions with character classes: [[:alnum:]], etc.
+
+	// [[:blank:]], [[:cntrl:]], [[:punct:]] and [[:space:]] will never match
+	re = regexp.MustCompile(`\[\[:(blank|cntrl|punct|space):\]\]`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, regexWillNeverMatch)
+	}
+
+	// [[^:ascii:]], [[^:graph:]], [[^:print:]] will never match
+	re = regexp.MustCompile(`\[\[\^:(ascii|graph|print):\]\]`)
+	if re.MatchString(s) {
+		return invalidRegexMsg(s, regexWillNeverMatch)
+	}
+
+	return ""
+}
+
+// removeMetacharacters removes regex metacharacters from the string
+func removeMetacharacters(s string) string {
+	// This logic isn't needed anymore, as we don't attempt to calculate the probability of regular expressions
+	// // remove (?i) from beginning of string
+	// re := regexp.MustCompile(`^\([^)]*\)`)
+	// s = re.ReplaceAllLiteralString(s, "")
+	// // replace [a-b]+ with x
+	// re = regexp.MustCompile(`\[[^]]*\]\+?`)
+	// s = re.ReplaceAllLiteralString(s, "x")
+	// // strip all {n}
+	// re = regexp.MustCompile(`\{[^}]+\}`)
+	// s = re.ReplaceAllLiteralString(s, "")
+	// // replace = with x
+	// re = regexp.MustCompile(`=`)
+	// s = re.ReplaceAllLiteralString(s, "x")
+
 	// strip out remaining regexp metacharacters
 	for _, rune1 := range []rune(regexChars) {
 		s = strings.ReplaceAll(s, string(rune1), "")

--- a/keygen/utils.go
+++ b/keygen/utils.go
@@ -5,8 +5,13 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
+
+// regexChars contains the list of regex metacharacters, excluding +,
+// which is valid in a key
+const regexChars = `^$.|?*-[]{}()\`
 
 // IsValidSearch checks the search does not contain any invalid characters
 func IsValidSearch(s string) bool {
@@ -86,4 +91,20 @@ func NumberFormat(n int64) string {
 			out[j] = ','
 		}
 	}
+}
+
+func RemoveMetacharacters(s string) string {
+	if !strings.ContainsAny(s, regexChars) {
+		return s
+	}
+	// remove (?i)
+	re1 := regexp.MustCompile(`^\([^)]*\)`)
+	s = re1.ReplaceAllLiteralString(s, "")
+	// replace [a-b]+ with a
+	re2 := regexp.MustCompile(`\[[^]]*\]\+?`)
+	s = re2.ReplaceAllLiteralString(s, "a")
+	for _, rune1 := range []rune(regexChars) {
+		s = strings.ReplaceAll(s, string(rune1), "")
+	}
+	return s
 }

--- a/keygen/utils.go
+++ b/keygen/utils.go
@@ -103,6 +103,10 @@ func RemoveMetacharacters(s string) string {
 	// replace [a-b]+ with a
 	re2 := regexp.MustCompile(`\[[^]]*\]\+?`)
 	s = re2.ReplaceAllLiteralString(s, "a")
+	// strip all {n}
+	re3 := regexp.MustCompile(`\{[^}]+\}`)
+	s = re3.ReplaceAllLiteralString(s, "")
+	// strip out remaining regexp metacharacters
 	for _, rune1 := range []rune(regexChars) {
 		s = strings.ReplaceAll(s, string(rune1), "")
 	}

--- a/keygen/worker.go
+++ b/keygen/worker.go
@@ -18,11 +18,11 @@ type Options struct {
 // Cruncher struct
 type Cruncher struct {
 	Options
-	WordMap        map[string]int
-	mapMutex       sync.RWMutex
-	RegexpMap      map[*regexp.Regexp]int
-	thread         chan int
-	Abort          bool // set to true to abort processing
+	WordMap   map[string]int
+	mapMutex  sync.RWMutex
+	RegexpMap map[*regexp.Regexp]int
+	thread    chan int
+	Abort     bool // set to true to abort processing
 }
 
 // Pair struct

--- a/main.go
+++ b/main.go
@@ -84,27 +84,27 @@ func main() {
 			os.Exit(2)
 		}
 		if stripped != sword {
+			fmt.Printf("Cannot calculate probability for a regular expression: %s\n", sword)
+
 			if !options.CaseSensitive {
 				sword = "(?i)" + sword
 			}
 			regex := regexp.MustCompile(sword)
 			c.RegexpMap[regex] = options.LimitResults
-		} else {
-			if !options.CaseSensitive {
-				sword = strings.ToLower(sword)
-			}
-			c.WordMap[sword] = options.LimitResults
+
+			continue
 		}
-		probability := keygen.CalculateProbability(stripped, options.CaseSensitive)
+
+		if !options.CaseSensitive {
+			sword = strings.ToLower(sword)
+		}
+		c.WordMap[sword] = options.LimitResults
+		probability := keygen.CalculateProbability(sword, options.CaseSensitive)
 		estimate64 := int64(speed) * probability
 		estimate := time.Duration(estimate64)
 
-		comment := ""
-		if len(stripped) != len(sword) {
-			comment = fmt.Sprintf(" (approximation may be wildly off, as '%s' is test string)", stripped)
-		}
-		fmt.Printf("Probability for \"%s\": 1 in %s (approx %s per match)%s\n",
-			word, keygen.NumberFormat(probability), keygen.HumanizeDuration(estimate), comment)
+		fmt.Printf("Probability for \"%s\": 1 in %s (approx %s per match)\n",
+			word, keygen.NumberFormat(probability), keygen.HumanizeDuration(estimate))
 	}
 
 	fmt.Printf("\nPress Ctrl-c to cancel\n\n")

--- a/main.go
+++ b/main.go
@@ -84,18 +84,17 @@ func main() {
 			os.Exit(2)
 		}
 		if stripped != sword {
-			fmt.Printf("Cannot calculate probability for a regular expression: %s\n", sword)
+			fmt.Printf("Cannot calculate probability for the regular expression \"%s\"\n", sword)
 
 			if !options.CaseSensitive {
 				sword = "(?i)" + sword
 			}
 			regex, err := regexp.Compile(sword)
 			if err != nil {
-				fmt.Printf("Invalid regular expression: %s: %v\n", word, err)
+				fmt.Printf("\n\"%s\" is an invalid regular expression: %v\n", word, err)
 				os.Exit(2)
 			}
 			c.RegexpMap[regex] = options.LimitResults
-
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -77,9 +77,6 @@ func main() {
 
 	for _, word := range args {
 		sword := word
-		if !options.CaseSensitive {
-			sword = strings.ToLower(sword)
-		}
 		stripped := keygen.RemoveMetacharacters(sword)
 		if !keygen.IsValidSearch(stripped) {
 			fmt.Printf("\n\"%s\" contains invalid characters\n", word)
@@ -87,9 +84,15 @@ func main() {
 			os.Exit(2)
 		}
 		if stripped != sword {
+			if !options.CaseSensitive {
+				sword = "(?i)" + sword
+			}
 			regex := regexp.MustCompile(sword)
 			c.RegexpMap[regex] = options.LimitResults
 		} else {
+			if !options.CaseSensitive {
+				sword = strings.ToLower(sword)
+			}
 			c.WordMap[sword] = options.LimitResults
 		}
 		probability := keygen.CalculateProbability(stripped, options.CaseSensitive)

--- a/main.go
+++ b/main.go
@@ -89,7 +89,11 @@ func main() {
 			if !options.CaseSensitive {
 				sword = "(?i)" + sword
 			}
-			regex := regexp.MustCompile(sword)
+			regex, err := regexp.Compile(sword)
+			if err != nil {
+				fmt.Printf("Invalid regular expression: %s: %v\n", sword, err)
+				os.Exit(2)
+			}
 			c.RegexpMap[regex] = options.LimitResults
 
 			continue

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 			}
 			regex, err := regexp.Compile(sword)
 			if err != nil {
-				fmt.Printf("Invalid regular expression: %s: %v\n", sword, err)
+				fmt.Printf("Invalid regular expression: %s: %v\n", word, err)
 				os.Exit(2)
 			}
 			c.RegexpMap[regex] = options.LimitResults


### PR DESCRIPTION
Fixes #12.

I tried to write logic that converts regexs such as `(abc|defg)` to `defg`, but I gave up, as it's non-trivial. The cost/benefit is not worth it :). Instead, I just note the issue in the readme.